### PR TITLE
Integer precision

### DIFF
--- a/native/cartesian/cartesian.f90
+++ b/native/cartesian/cartesian.f90
@@ -38,9 +38,9 @@ contains
         complex(real64), intent(inout) :: vec(local_i)
 
         real(real64), dimension(n_dim) :: grid_point
-        integer(int32) :: i, j
+        integer(int64) :: i
 
-        do i = local_i_offset + 1, local_i + local_i_offset
+        do i = local_i_offset + 1_int64, local_i + local_i_offset
             call get_index(i, n_dim, Ns, strides, grid_point)
             grid_point = mins + (grid_point - 1.0_real64) * deltas
 !f2py (callback) f
@@ -60,7 +60,7 @@ contains
         complex(real64), parameter :: cI = cmplx(0.0_real64, 1.0_real64, real64)
         real(real64), parameter :: pi = 4.0_real64 * atan(1.0_real64)
 
-        integer(int32), intent(in) :: i
+        integer(int64), intent(in) :: i
         integer(int32), intent(in) :: n_dim
         integer(int32), intent(in) :: Ns(n_dim)
         integer(int64), intent(in) :: strides(n_dim)
@@ -102,9 +102,9 @@ contains
         real(real64), intent(out) :: local_grid(local_i, n_dim)
 
         real(real64) :: grid_point(n_dim)
-        integer(int32) :: i
+        integer(int64) :: i
 
-        do i = local_i_offset + 1, local_i + local_i_offset
+        do i = local_i_offset + 1_int64, local_i + local_i_offset
             call get_index(i, n_dim, Ns, strides, grid_point)
             local_grid(i - local_i_offset, :) = mins + (grid_point - 1.0_real64) * deltas
         end do

--- a/native/io/io.f90
+++ b/native/io/io.f90
@@ -74,8 +74,8 @@ contains
         character(len=512), intent(in) :: dataset_name
         character(len=1), intent(in) :: access_type
         integer(int64), intent(in) :: N
-        integer(int32), intent(in) :: local_i
-        integer(int32), intent(in) :: local_i_offset
+        integer(int64), intent(in) :: local_i
+        integer(int64), intent(in) :: local_i_offset
         complex(real64), dimension(local_i), intent(in) :: complex_array
         integer(int32), intent(in) :: MPI_communicator
 
@@ -84,8 +84,8 @@ contains
 !f2py  character*512 intent(in) :: dataset_name
 !f2py  character*1 intent(in) :: access_type
 !f2py  integer(kind=int64) intent(in) :: n
-!f2py  integer(kind=int32), optional,intent(in),check(shape(complex_array, 0) == local_i),depend(complex_array) :: local_i=shape(complex_array, 0)
-!f2py  integer(kind=int32) intent(in) :: local_i_offset
+!f2py  integer(kind=int64), optional,intent(in),check(shape(complex_array, 0) == local_i),depend(complex_array) :: local_i=shape(complex_array, 0)
+!f2py  integer(kind=int64) intent(in) :: local_i_offset
 !f2py  complex(kind=real64) dimension(local_i),intent(in) :: complex_array
 !f2py  integer(kind=int32) intent(in) :: mpi_communicator
 
@@ -289,8 +289,8 @@ contains
         character(len=512), intent(in) :: dataset_name
         character(len=1), intent(in) :: access_type
         integer(int64), intent(in) :: N
-        integer(int32), intent(in) :: local_i
-        integer(int32), intent(in) :: local_i_offset
+        integer(int64), intent(in) :: local_i
+        integer(int64), intent(in) :: local_i_offset
         real(real64), dimension(local_i), intent(in) :: real_array
         integer(int32), intent(in) :: MPI_communicator
 
@@ -299,8 +299,8 @@ contains
 !f2py  character*512 intent(in) :: dataset_name
 !f2py  character*1 intent(in) :: access_type
 !f2py  integer(kind=int64) intent(in) :: n
-!f2py  integer(kind=int32), optional,intent(in),check(shape(real_array, 0) == local_i),depend(real_array) :: local_i=shape(real_array, 0)
-!f2py  integer(kind=int32) intent(in) :: local_i_offset
+!f2py  integer(kind=int64), optional,intent(in),check(shape(real_array, 0) == local_i),depend(real_array) :: local_i=shape(real_array, 0)
+!f2py  integer(kind=int64) intent(in) :: local_i_offset
 !f2py  real(kind=real64) dimension(local_i) :: real_array
 !f2py  integer(kind=int32) intent(in) :: mpi_communicator
 

--- a/native/mpi/multivariable/mpi_composite.f90
+++ b/native/mpi/multivariable/mpi_composite.f90
@@ -379,7 +379,7 @@ contains
 
         self%mixer = 0
         do i = ci_local_i_offset + 1, ci_local_i + ci_local_i_offset
-            call get_index(int(i, int32), n_dim, self%Ns, self%strides, inds)
+            call get_index(i, n_dim, self%Ns, self%strides, inds)
             do j = 1, n_dim
                 self%mixer(i - ci_local_i_offset) = &
                     self%mixer(i - ci_local_i_offset) &

--- a/native/mpi/multivariable/mpi_momentum.f90
+++ b/native/mpi/multivariable/mpi_momentum.f90
@@ -365,7 +365,7 @@ contains
         end do
 
         do i_global = ci_local_i_offset + 1, ci_local_i + ci_local_i_offset
-            call get_index(int(i_global, int32), int(n_dim, int32), self%Ns, self%strides, inds(1:n_dim))
+            call get_index(i_global, int(n_dim, int32), self%Ns, self%strides, inds(1:n_dim))
 
             grid_point(1:n_dim) = self%minsk(1:n_dim) + (inds(1:n_dim) - 1.0_real64) * self%deltask(1:n_dim)
             self%phase_k(i_global - ci_local_i_offset) = exp(-cI * sum(grid_point(1:n_dim) * self%minsq(1:n_dim)))
@@ -407,7 +407,7 @@ contains
         end if
 
         do i = ci_local_i_offset + 1, ci_local_i + ci_local_i_offset
-            call get_index(int(i, int32), n_dim, self%Ns, self%strides, inds)
+            call get_index(i, n_dim, self%Ns, self%strides, inds)
             self%context%state(i - ci_local_i_offset) = &
                 ((-1.0_real64)**real(sum(inds - 1), real64)) * self%context%state(i - ci_local_i_offset)
         end do
@@ -419,7 +419,7 @@ contains
 
         self%mixer = cmplx(0.0_real64, 0.0_real64, real64)
         do i = ci_local_i_offset + 1, ci_local_i + ci_local_i_offset
-            call get_index(int(i, int32), n_dim, self%Ns, self%strides, inds)
+            call get_index(i, n_dim, self%Ns, self%strides, inds)
             do j = 1, n_dim
                 self%mixer(i - ci_local_i_offset) = self%mixer(i - ci_local_i_offset) &
                                                     + t_temp(j) * self%eigenvalues(int(inds(j)), j)
@@ -430,7 +430,7 @@ contains
             exp(-cI * self%mixer) * self%context%state(1:ci_local_i)
 
         do i = ci_local_i_offset + 1, ci_local_i + ci_local_i_offset
-            call get_index(int(i, int32), n_dim, self%Ns, self%strides, inds)
+            call get_index(i, n_dim, self%Ns, self%strides, inds)
             self%context%state(i - ci_local_i_offset) = &
                 ((-1.0_real64)**real(sum(inds - 1), real64)) * self%context%state(i - ci_local_i_offset)
         end do

--- a/native/sparse_vector/sparse_vector.f90
+++ b/native/sparse_vector/sparse_vector.f90
@@ -23,12 +23,13 @@ contains
 
         integer(int32) :: rank, flock
         integer(int32), dimension(:), allocatable :: counts, disps
+        integer(int64) :: global_i
         integer(int32) :: i, ierr
 
         local_nnz = 0
 
-        do i = local_i_offset + 1, local_i_offset + local_i
-            if (abs(dense_array(i)) > epsilon(1.0_real64)) then
+        do global_i = local_i_offset + 1_int64, local_i_offset + local_i
+            if (abs(dense_array(global_i)) > epsilon(1.0_real64)) then
                 local_nnz = local_nnz + 1
             end if
         end do
@@ -37,11 +38,11 @@ contains
 
         local_nnz = 0
 
-        do i = local_i_offset + 1, local_i_offset + local_i
-            if (abs(dense_array(i)) > epsilon(1.0_real64)) then
+        do global_i = local_i_offset + 1_int64, local_i_offset + local_i
+            if (abs(dense_array(global_i)) > epsilon(1.0_real64)) then
                 local_nnz = local_nnz + 1
-                local_indexes(local_nnz) = i
-                local_values(local_nnz) = dense_array(i)
+                local_indexes(local_nnz) = global_i
+                local_values(local_nnz) = dense_array(global_i)
             end if
         end do
 


### PR DESCRIPTION
This pull request fixes an integer overflow failure triggered in large-scale simulations due to `io.f90` casting `local_i` and `local_i_offset` to `int32`. It also pre-emptively corrects instances elsewhere in the native codebase where these variables were still typed as `int32` or indexed by `int32` integers. 